### PR TITLE
feat: implement user-owned Google Drive & Sheets integration

### DIFF
--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -1,23 +1,19 @@
 import { Injectable } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
-
-interface GoogleUser {
-  googleId: string;
-  email: string;
-  firstName: string;
-  lastName: string;
-}
+import type { GoogleUser, JwtPayload } from '@crm/types';
 
 @Injectable()
 export class AuthService {
   constructor(private jwtService: JwtService) {}
 
   login(user: GoogleUser): string {
-    const payload = {
+    const payload: JwtPayload = {
       sub: user.googleId,
       email: user.email,
       firstName: user.firstName,
       lastName: user.lastName,
+      accessToken: user.accessToken,
+      refreshToken: user.refreshToken,
     };
     return this.jwtService.sign(payload);
   }

--- a/apps/api/src/auth/google.strategy.ts
+++ b/apps/api/src/auth/google.strategy.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { Strategy, VerifyCallback } from 'passport-google-oauth20';
 import { ConfigService } from '@nestjs/config';
+import type { GoogleUser } from '@crm/types';
 
 @Injectable()
 export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
@@ -14,8 +15,18 @@ export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
       callbackURL:
         configService.get<string>('GOOGLE_OAUTH_CALLBACK_URL') ??
         'http://localhost:3000/auth/google/callback',
-      scope: ['email', 'profile'],
+      scope: [
+        'email',
+        'profile',
+        'https://www.googleapis.com/auth/drive.file',
+        'https://www.googleapis.com/auth/spreadsheets',
+      ],
     });
+  }
+
+  // Request offline access and force consent to always receive a refresh token.
+  authorizationParams(): Record<string, string> {
+    return { access_type: 'offline', prompt: 'consent' };
   }
 
   validate(
@@ -25,11 +36,13 @@ export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
     done: VerifyCallback,
   ): void {
     const { name, emails } = profile;
-    const user = {
+    const user: GoogleUser = {
       googleId: profile.id,
       email: emails[0].value,
       firstName: name.givenName,
       lastName: name.familyName,
+      accessToken,
+      refreshToken,
     };
     done(null, user);
   }

--- a/apps/api/src/customers/customers.controller.ts
+++ b/apps/api/src/customers/customers.controller.ts
@@ -7,29 +7,45 @@ import {
   Param,
   HttpCode,
   UseGuards,
+  Req,
 } from '@nestjs/common';
+import type { Request } from 'express';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard.js';
 import { SheetsService } from './sheets.service.js';
-import type { CreateCustomerDto, UpdateCustomerDto } from '@crm/types';
+import { DriveService } from './drive.service.js';
+import type { CreateCustomerDto, UpdateCustomerDto, JwtPayload } from '@crm/types';
 
 @UseGuards(JwtAuthGuard)
 @Controller('customers')
 export class CustomersController {
-  constructor(private readonly sheetsService: SheetsService) {}
+  constructor(
+    private readonly sheetsService: SheetsService,
+    private readonly driveService: DriveService,
+  ) {}
+
+  private getUser(req: Request): JwtPayload {
+    return req.user as JwtPayload;
+  }
 
   @Get()
-  getAll() {
-    return this.sheetsService.getAll();
+  async getAll(@Req() req: Request) {
+    const { sub, accessToken, refreshToken } = this.getUser(req);
+    const spreadsheetId = await this.driveService.getOrCreateSpreadsheet(sub, accessToken, refreshToken);
+    return this.sheetsService.getAll(accessToken, refreshToken, spreadsheetId);
   }
 
   @Post()
   @HttpCode(201)
-  create(@Body() dto: CreateCustomerDto) {
-    return this.sheetsService.append(dto);
+  async create(@Req() req: Request, @Body() dto: CreateCustomerDto) {
+    const { sub, accessToken, refreshToken } = this.getUser(req);
+    const spreadsheetId = await this.driveService.getOrCreateSpreadsheet(sub, accessToken, refreshToken);
+    return this.sheetsService.append(dto, accessToken, refreshToken, spreadsheetId);
   }
 
   @Patch(':id')
-  update(@Param('id') id: string, @Body() dto: UpdateCustomerDto) {
-    return this.sheetsService.update(id, dto);
+  async update(@Req() req: Request, @Param('id') id: string, @Body() dto: UpdateCustomerDto) {
+    const { sub, accessToken, refreshToken } = this.getUser(req);
+    const spreadsheetId = await this.driveService.getOrCreateSpreadsheet(sub, accessToken, refreshToken);
+    return this.sheetsService.update(id, dto, accessToken, refreshToken, spreadsheetId);
   }
 }

--- a/apps/api/src/customers/customers.module.ts
+++ b/apps/api/src/customers/customers.module.ts
@@ -2,10 +2,11 @@ import { Module } from '@nestjs/common';
 import { AuthModule } from '../auth/auth.module.js';
 import { CustomersController } from './customers.controller.js';
 import { SheetsService } from './sheets.service.js';
+import { DriveService } from './drive.service.js';
 
 @Module({
   imports: [AuthModule],
   controllers: [CustomersController],
-  providers: [SheetsService],
+  providers: [SheetsService, DriveService],
 })
 export class CustomersModule {}

--- a/apps/api/src/customers/drive.service.ts
+++ b/apps/api/src/customers/drive.service.ts
@@ -1,0 +1,106 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { google } from 'googleapis';
+import type { OAuth2Client } from 'google-auth-library';
+
+const SHEET_HEADERS = [
+  'id', 'first_name', 'last_name', 'email', 'phone',
+  'company', 'status', 'last_contact_date', 'notes', 'created_at',
+];
+const DRIVE_FOLDER_NAME = 'crm';
+const SPREADSHEET_NAME = 'customers';
+
+@Injectable()
+export class DriveService {
+  private readonly logger = new Logger(DriveService.name);
+  private readonly spreadsheetCache = new Map<string, string>();
+
+  constructor(private readonly configService: ConfigService) {}
+
+  private buildOAuth2Client(accessToken: string, refreshToken: string): OAuth2Client {
+    const client = new google.auth.OAuth2(
+      this.configService.get<string>('GOOGLE_OAUTH_CLIENT_ID'),
+      this.configService.get<string>('GOOGLE_OAUTH_CLIENT_SECRET'),
+    );
+    client.setCredentials({ access_token: accessToken, refresh_token: refreshToken });
+    return client;
+  }
+
+  async getOrCreateSpreadsheet(
+    userId: string,
+    accessToken: string,
+    refreshToken: string,
+  ): Promise<string> {
+    const cached = this.spreadsheetCache.get(userId);
+    if (cached) return cached;
+
+    const auth = this.buildOAuth2Client(accessToken, refreshToken);
+    const folderId = await this.findOrCreateFolder(auth);
+    const spreadsheetId = await this.findOrCreateSpreadsheet(auth, folderId);
+    this.spreadsheetCache.set(userId, spreadsheetId);
+    this.logger.log(`Resolved spreadsheet ${spreadsheetId} for user ${userId}`);
+    return spreadsheetId;
+  }
+
+  private async findOrCreateFolder(auth: OAuth2Client): Promise<string> {
+    const drive = google.drive({ version: 'v3', auth });
+    const res = await drive.files.list({
+      q: `name='${DRIVE_FOLDER_NAME}' and mimeType='application/vnd.google-apps.folder' and trashed=false`,
+      fields: 'files(id)',
+      spaces: 'drive',
+    });
+    const files = res.data.files ?? [];
+    if (files.length > 0 && files[0].id) return files[0].id;
+
+    const created = await drive.files.create({
+      requestBody: { name: DRIVE_FOLDER_NAME, mimeType: 'application/vnd.google-apps.folder' },
+      fields: 'id',
+    });
+    this.logger.log(`Created Drive folder: ${created.data.id}`);
+    return created.data.id!;
+  }
+
+  private async findOrCreateSpreadsheet(
+    auth: OAuth2Client,
+    folderId: string,
+  ): Promise<string> {
+    const drive = google.drive({ version: 'v3', auth });
+    const res = await drive.files.list({
+      q: `name='${SPREADSHEET_NAME}' and mimeType='application/vnd.google-apps.spreadsheet' and '${folderId}' in parents and trashed=false`,
+      fields: 'files(id)',
+      spaces: 'drive',
+    });
+    const files = res.data.files ?? [];
+    if (files.length > 0 && files[0].id) return files[0].id;
+
+    const sheets = google.sheets({ version: 'v4', auth });
+    const created = await sheets.spreadsheets.create({
+      requestBody: {
+        properties: { title: SPREADSHEET_NAME },
+        sheets: [{
+          properties: { title: 'Sheet1' },
+          data: [{
+            startRow: 0,
+            startColumn: 0,
+            rowData: [{
+              values: SHEET_HEADERS.map((h) => ({ userEnteredValue: { stringValue: h } })),
+            }],
+          }],
+        }],
+      },
+      fields: 'spreadsheetId',
+    });
+    const spreadsheetId = created.data.spreadsheetId!;
+
+    // Move the new spreadsheet into the crm folder
+    await drive.files.update({
+      fileId: spreadsheetId,
+      addParents: folderId,
+      removeParents: 'root',
+      fields: 'id',
+    });
+
+    this.logger.log(`Created spreadsheet ${spreadsheetId} in folder ${folderId}`);
+    return spreadsheetId;
+  }
+}

--- a/apps/api/src/customers/sheets.service.ts
+++ b/apps/api/src/customers/sheets.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { google, sheets_v4 } from 'googleapis';
+import type { OAuth2Client } from 'google-auth-library';
 import type {
   Customer,
   CreateCustomerDto,
@@ -11,35 +12,15 @@ const SHEET_RANGE = 'Sheet1!A:J';
 
 @Injectable()
 export class SheetsService {
-  private readonly sheets: sheets_v4.Sheets;
-  private readonly spreadsheetId: string;
+  constructor(private readonly configService: ConfigService) {}
 
-  constructor(private readonly configService: ConfigService) {
-    const rawKey = this.configService.get<string>('GOOGLE_SERVICE_ACCOUNT_KEY') ?? '';
-    const email = this.configService.get<string>('GOOGLE_SERVICE_ACCOUNT_EMAIL') ?? '';
-
-    // Parse JSON key if provided; fall back to treating rawKey as the private key directly
-    let privateKey = rawKey;
-    let clientEmail = email;
-    try {
-      const parsed = JSON.parse(rawKey) as { client_email?: string; private_key?: string };
-      privateKey = parsed.private_key ?? rawKey;
-      clientEmail = email || parsed.client_email || '';
-    } catch {
-      // rawKey is not JSON — treat it as the raw private key string
-    }
-
-    // Env vars store literal \n — replace with real newlines for the PEM key
-    privateKey = privateKey.replace(/\\n/g, '\n');
-
-    const auth = new google.auth.JWT({
-      email: clientEmail,
-      key: privateKey,
-      scopes: ['https://www.googleapis.com/auth/spreadsheets'],
-    });
-
-    this.sheets = google.sheets({ version: 'v4', auth });
-    this.spreadsheetId = this.configService.get<string>('GOOGLE_SHEET_ID') ?? '';
+  private buildSheetsClient(accessToken: string, refreshToken: string): sheets_v4.Sheets {
+    const auth: OAuth2Client = new google.auth.OAuth2(
+      this.configService.get<string>('GOOGLE_OAUTH_CLIENT_ID'),
+      this.configService.get<string>('GOOGLE_OAUTH_CLIENT_SECRET'),
+    );
+    auth.setCredentials({ access_token: accessToken, refresh_token: refreshToken });
+    return google.sheets({ version: 'v4', auth });
   }
 
   // ── Helpers ──────────────────────────────────────────────────────────────
@@ -76,19 +57,28 @@ export class SheetsService {
 
   // ── Public API ────────────────────────────────────────────────────────────
 
-  async getAll(): Promise<Customer[]> {
-    const response = await this.sheets.spreadsheets.values.get({
-      spreadsheetId: this.spreadsheetId,
+  async getAll(
+    accessToken: string,
+    refreshToken: string,
+    spreadsheetId: string,
+  ): Promise<Customer[]> {
+    const sheets = this.buildSheetsClient(accessToken, refreshToken);
+    const response = await sheets.spreadsheets.values.get({
+      spreadsheetId,
       range: SHEET_RANGE,
     });
 
     const rows = response.data.values ?? [];
-
-    // Skip header row (index 0)
     return rows.slice(1).map((row) => this.rowToCustomer(row as string[]));
   }
 
-  async append(dto: CreateCustomerDto): Promise<Customer> {
+  async append(
+    dto: CreateCustomerDto,
+    accessToken: string,
+    refreshToken: string,
+    spreadsheetId: string,
+  ): Promise<Customer> {
+    const sheets = this.buildSheetsClient(accessToken, refreshToken);
     const now = new Date().toISOString();
     const id = crypto.randomUUID();
 
@@ -105,8 +95,8 @@ export class SheetsService {
       createdAt: now,
     };
 
-    await this.sheets.spreadsheets.values.append({
-      spreadsheetId: this.spreadsheetId,
+    await sheets.spreadsheets.values.append({
+      spreadsheetId,
       range: SHEET_RANGE,
       valueInputOption: 'RAW',
       requestBody: {
@@ -117,14 +107,20 @@ export class SheetsService {
     return customer;
   }
 
-  async update(id: string, dto: UpdateCustomerDto): Promise<Customer> {
-    const response = await this.sheets.spreadsheets.values.get({
-      spreadsheetId: this.spreadsheetId,
+  async update(
+    id: string,
+    dto: UpdateCustomerDto,
+    accessToken: string,
+    refreshToken: string,
+    spreadsheetId: string,
+  ): Promise<Customer> {
+    const sheets = this.buildSheetsClient(accessToken, refreshToken);
+    const response = await sheets.spreadsheets.values.get({
+      spreadsheetId,
       range: SHEET_RANGE,
     });
 
     const rows = response.data.values ?? [];
-    // rows[0] is the header row, data starts at rows[1]
     const dataRows = rows.slice(1) as string[][];
     const dataIndex = dataRows.findIndex((row) => row[0] === id);
 
@@ -146,11 +142,9 @@ export class SheetsService {
       createdAt: existing.createdAt,
     };
 
-    // Row number in the sheet: header is row 1, first data row is row 2
     const sheetRowNumber = dataIndex + 2;
-
-    await this.sheets.spreadsheets.values.update({
-      spreadsheetId: this.spreadsheetId,
+    await sheets.spreadsheets.values.update({
+      spreadsheetId,
       range: `Sheet1!A${sheetRowNumber}:J${sheetRowNumber}`,
       valueInputOption: 'RAW',
       requestBody: {

--- a/apps/web/src/components/customers/CustomerDrawer.tsx
+++ b/apps/web/src/components/customers/CustomerDrawer.tsx
@@ -59,7 +59,7 @@ export function CustomerDrawer({
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent
         side="right"
-        className="w-[440px] sm:max-w-[440px] p-0 flex flex-col"
+        className="w-[440px] sm:max-w-[440px] p-0 flex flex-col bg-white"
         style={{ boxShadow: 'var(--shadow-modal)' }}
       >
         {/* Header */}

--- a/apps/web/src/components/ui/sheet.tsx
+++ b/apps/web/src/components/ui/sheet.tsx
@@ -3,7 +3,6 @@
 import * as React from "react"
 import * as SheetPrimitive from "@radix-ui/react-dialog"
 import { cva, type VariantProps } from "class-variance-authority"
-import { X } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
@@ -69,10 +68,6 @@ const SheetContent = React.forwardRef<
       {...props}
     >
       {children}
-      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </SheetPrimitive.Close>
     </SheetPrimitive.Content>
   </SheetPortal>
 ))

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -35,6 +35,11 @@
   --shadow-modal: 0 20px 60px rgba(13,31,45,0.18), 0 4px 16px rgba(13,31,45,0.10);
   --focus-ring: #1A7A6E;
   --destructive: #C94040;
+
+  --background: 0 0% 100%;
+  --foreground: 20 14% 7%;
+  --muted-foreground: 25 5% 40%;
+  --ring: 172 64% 29%;
 }
 
 @keyframes fadeUp {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -16,9 +16,20 @@ export interface Customer {
 export interface CreateCustomerDto extends Omit<Customer, 'id' | 'createdAt'> {}
 export interface UpdateCustomerDto extends Partial<CreateCustomerDto> {}
 
+export interface GoogleUser {
+  googleId: string;
+  email: string;
+  firstName: string;
+  lastName: string;
+  accessToken: string;
+  refreshToken: string;
+}
+
 export interface JwtPayload {
   sub: string;
   email: string;
   firstName: string;
   lastName: string;
+  accessToken: string;
+  refreshToken: string;
 }


### PR DESCRIPTION
## Summary

- **Auth layer**: `GoogleStrategy` now requests `drive.file` + `spreadsheets` OAuth scopes with `access_type=offline` / `prompt=consent` to obtain a refresh token; `accessToken` and `refreshToken` are embedded in the signed JWT via `AuthService`
- **DriveService** (new): per-user lazy creation of a `crm` folder and `customers` spreadsheet in Google Drive using the user's own OAuth tokens — nothing is created until the first API request
- **SheetsService**: removed global Service Account configuration; all methods now accept `accessToken`, `refreshToken`, and a dynamic `spreadsheetId` resolved by `DriveService`
- **CustomersController**: extracts tokens from the JWT on every request, calls `DriveService.getOrCreateSpreadsheet`, then delegates to `SheetsService`
- **Shared types**: `GoogleUser` interface added; `JwtPayload` extended with token fields
- **UI fixes**: transparent `CustomerDrawer` background resolved (`bg-white` + `--background` CSS variable); duplicate close button removed from `SheetContent`

## Test plan

- [ ] Log in via Google OAuth — verify Drive/Sheets permission consent screen appears
- [ ] View customer list — verify a `crm` folder and `customers` sheet are created in your Google Drive on first access
- [ ] Add a customer — verify a new row appears in the `customers` sheet with correct schema
- [ ] Edit a customer — verify the correct row is updated in the sheet
- [ ] Open "Add Customer" drawer — verify it renders with a white (opaque) background and a single close button

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)