### PR TITLE
feat: silent optimistic update for Kanban customer (closes #10)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -27,7 +27,8 @@
     "lucide-react": "^0.577.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "tailwind-merge": "^3.5.0"
+    "tailwind-merge": "^3.5.0",
+    "zustand": "^5.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/apps/web/src/hooks/useCustomers.ts
+++ b/apps/web/src/hooks/useCustomers.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import type { Customer, CustomerStatus, CreateCustomerDto, UpdateCustomerDto } from '@crm/types';
-import { apiFetch } from '@/lib/api';
 import { toast } from '@/hooks/use-toast';
+import { useCustomerStore } from '@/store/customerStore';
 
 export type SortDirection = 'asc' | 'desc';
 
@@ -28,33 +28,21 @@ export interface UseCustomersReturn {
 }
 
 export function useCustomers(): UseCustomersReturn {
-  const [customers, setCustomers] = useState<Customer[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  // --- store-backed state ---
+  const customers = useCustomerStore((s) => s.customers);
+  const isLoading = useCustomerStore((s) => s.isLoading);
+  const error = useCustomerStore((s) => s.error);
+  const fetchCustomers = useCustomerStore((s) => s.fetchCustomers);
+  const storeUpdateCustomer = useCustomerStore((s) => s.updateCustomer);
+  const storeAddCustomer = useCustomerStore((s) => s.addCustomer);
+
+  // --- view-local state ---
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState<CustomerStatus | 'All'>('All');
   const [sortColumn, setSortColumnState] = useState<keyof Customer | null>(null);
   const [sortDirection, setSortDirection] = useState<SortDirection>('asc');
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [editingCustomer, setEditingCustomer] = useState<Customer | null>(null);
-
-  const fetchCustomers = useCallback(async () => {
-    setIsLoading(true);
-    setError(null);
-    try {
-      const res = await apiFetch('/customers');
-      if (!res.ok) {
-        throw new Error(`Failed to fetch customers (${res.status})`);
-      }
-      const data = (await res.json()) as Customer[];
-      setCustomers(data);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to load customers';
-      setError(message);
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
 
   useEffect(() => {
     void fetchCustomers();
@@ -65,10 +53,11 @@ export function useCustomers(): UseCustomersReturn {
 
     if (searchQuery.trim()) {
       const q = searchQuery.toLowerCase();
-      result = result.filter((c) =>
-        `${c.firstName} ${c.lastName}`.toLowerCase().includes(q) ||
-        c.email.toLowerCase().includes(q) ||
-        c.company.toLowerCase().includes(q)
+      result = result.filter(
+        (c) =>
+          `${c.firstName} ${c.lastName}`.toLowerCase().includes(q) ||
+          c.email.toLowerCase().includes(q) ||
+          c.company.toLowerCase().includes(q),
       );
     }
 
@@ -106,31 +95,17 @@ export function useCustomers(): UseCustomersReturn {
   const submitCustomer = useCallback(
     async (data: CreateCustomerDto | UpdateCustomerDto) => {
       try {
-        let res: Response;
         if (editingCustomer) {
-          res = await apiFetch(`/customers/${editingCustomer.id}`, {
-            method: 'PATCH',
-            body: JSON.stringify(data),
-          });
+          await storeUpdateCustomer(editingCustomer.id, data as UpdateCustomerDto);
+          // store fires success/failure toast for updates; just close the drawer
         } else {
-          res = await apiFetch('/customers', {
-            method: 'POST',
-            body: JSON.stringify(data),
+          await storeAddCustomer(data as CreateCustomerDto);
+          toast({
+            title: 'Customer added',
+            description: 'New customer has been added successfully.',
           });
         }
-
-        if (!res.ok) {
-          throw new Error(`Request failed (${res.status})`);
-        }
-
-        await fetchCustomers();
         closeDrawer();
-        toast({
-          title: editingCustomer ? 'Customer updated' : 'Customer added',
-          description: editingCustomer
-            ? 'The customer record has been updated successfully.'
-            : 'New customer has been added successfully.',
-        });
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Something went wrong';
         toast({
@@ -141,21 +116,16 @@ export function useCustomers(): UseCustomersReturn {
         throw err;
       }
     },
-    [editingCustomer, fetchCustomers, closeDrawer]
+    [editingCustomer, storeUpdateCustomer, storeAddCustomer, closeDrawer],
   );
 
+  // Delegates directly to the store — no fetchCustomers() call, so isLoading
+  // never flips to true during a Kanban drag (the optimistic update is instant).
   const updateCustomer = useCallback(
     async (id: string, data: UpdateCustomerDto): Promise<void> => {
-      const res = await apiFetch(`/customers/${id}`, {
-        method: 'PATCH',
-        body: JSON.stringify(data),
-      });
-      if (!res.ok) {
-        throw new Error(`Request failed (${res.status})`);
-      }
-      await fetchCustomers();
+      await storeUpdateCustomer(id, data);
     },
-    [fetchCustomers]
+    [storeUpdateCustomer],
   );
 
   const setSortColumn = useCallback(
@@ -167,7 +137,7 @@ export function useCustomers(): UseCustomersReturn {
         setSortDirection('asc');
       }
     },
-    [sortColumn]
+    [sortColumn],
   );
 
   return {

--- a/apps/web/src/store/customerStore.ts
+++ b/apps/web/src/store/customerStore.ts
@@ -1,0 +1,65 @@
+import { create } from 'zustand';
+import type { Customer, UpdateCustomerDto, CreateCustomerDto } from '@crm/types';
+import { apiFetch } from '@/lib/api';
+import { toast } from '@/hooks/use-toast';
+
+interface CustomerState {
+  customers: Customer[];
+  isLoading: boolean;
+  error: string | null;
+  fetchCustomers: () => Promise<void>;
+  updateCustomer: (id: string, data: UpdateCustomerDto) => Promise<void>;
+  addCustomer: (data: CreateCustomerDto) => Promise<Customer>;
+}
+
+export const useCustomerStore = create<CustomerState>((set, get) => ({
+  customers: [],
+  isLoading: false,
+  error: null,
+
+  fetchCustomers: async () => {
+    set({ isLoading: true, error: null });
+    try {
+      const res = await apiFetch('/customers');
+      if (!res.ok) throw new Error(`Failed to fetch customers (${res.status})`);
+      const data = (await res.json()) as Customer[];
+      set({ customers: data });
+    } catch (err) {
+      set({ error: err instanceof Error ? err.message : 'Failed to load customers' });
+    } finally {
+      set({ isLoading: false });
+    }
+  },
+
+  updateCustomer: async (id, data) => {
+    const prev = get().customers;
+    set({ customers: prev.map((c) => (c.id === id ? { ...c, ...data } : c)) });
+    try {
+      const res = await apiFetch(`/customers/${id}`, {
+        method: 'PATCH',
+        body: JSON.stringify(data),
+      });
+      if (!res.ok) throw new Error(`Request failed (${res.status})`);
+      toast({ title: 'Customer updated', description: 'Status updated successfully.' });
+    } catch (err) {
+      set({ customers: prev });
+      toast({
+        title: 'Update failed',
+        description: err instanceof Error ? err.message : 'Something went wrong',
+        variant: 'destructive',
+      });
+      throw err;
+    }
+  },
+
+  addCustomer: async (data) => {
+    const res = await apiFetch('/customers', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+    if (!res.ok) throw new Error(`Request failed (${res.status})`);
+    const created = (await res.json()) as Customer;
+    set({ customers: [...get().customers, created] });
+    return created;
+  },
+}));

--- a/package-lock.json
+++ b/package-lock.json
@@ -7333,7 +7333,8 @@
         "lucide-react": "^0.577.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
-        "tailwind-merge": "^3.5.0"
+        "tailwind-merge": "^3.5.0",
+        "zustand": "^5.0.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -14996,6 +14997,35 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/zustand": {
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.11.tgz",
+      "integrity": "sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
+      }
     },
     "packages/types": {
       "name": "@crm/types",


### PR DESCRIPTION
## Summary

- Introduces a Zustand global store (`customerStore.ts`) that owns `customers`, `isLoading`, and `error` state
- `updateCustomer` in the store performs an **optimistic update**: card moves instantly, PATCH fires in the background, green toast on success, red toast + UI revert on failure
- `useCustomers` hook now delegates all data state and mutations to the store — `fetchCustomers()` is no longer called after a drag, so `isLoading` never flips `true` and the skeleton never appears mid-drag
- `zustand ^5.0.0` added to `apps/web` dependencies

## Test plan

- [x] All 29 vitest unit tests pass (`npm run test` in `apps/web`)
- [ ] Open Kanban view, drag a card between columns — card moves instantly, no skeleton flash
- [ ] Green success toast appears after drag
- [ ] Reload page — backend persisted the change
- [ ] Simulate failure (block network or sabotage URL) — card reverts and red error toast appears

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)